### PR TITLE
Install Bison on macOS and Windows, run tests and fix some issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,6 +148,7 @@ windows1809_vs2017: &windows1809_vs2017
     # simply add the extracted folder to the path.
     - choco install innoextract
     - choco install maven --ignore-dependencies
+    - choco install winflexbison3
     - wget -q https://dl.bintray.com/conan/installers/conan-win-64_1_10_0.exe
     - innoextract conan-win-64_1_10_0.exe
     - eval "export PATH=\"$(pwd)/app/conan:${PATH}\""

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,13 +97,14 @@ macos1015_xcode11_6: &macos1015_xcode11_6
   compiler: clang
   addons:
     homebrew:
-      packages: [ pyenv-virtualenv ]
+      packages: [ pyenv-virtualenv, bison ]
   before_install:
     - eval "export CC=clang CXX=clang++"
     - eval "export COV_COMPTYPE=clang COV_PLATFORM=macOSX"
     - eval "export BUILD_TOOL_OPTIONS='-j 4'"
     - eval "export GENERATOR='Unix Makefiles'"
     - eval "export PATH=\"${PATH}:$(python3 -m site --user-base)/bin\""
+    - eval "export PATH=\"/usr/local/opt/bison/bin:${PATH}\""
   install:
     - python3 -m pip install conan --upgrade --user
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -199,12 +199,15 @@ script:
   - *build_cyclonedds
   - mkdir build
   - cd build
+  - conan install -b missing -s arch=${ARCH} -s build_type=${BUILD_TYPE} ../${CONANFILE:-conanfile.txt}
   - ${SCAN_BUILD} cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
           -DCMAKE_INSTALL_PREFIX=$(pwd)/install
           -DCMAKE_PREFIX_PATH=${TRAVIS_BUILD_DIR}/cyclonedds/build/install
           -DUSE_SANITIZER=${SANITIZER}
+          -DBUILD_TESTING=on
           -G "${GENERATOR}" ..
   - cmake --build . --config ${BUILD_TYPE} --target install -- ${BUILD_TOOL_OPTIONS}
+  - ctest -j 4 --output-on-failure -T test -C ${BUILD_TYPE}
 
 after_success:
   - *submit_to_coverity_scan

--- a/src/idlcxx/src/backendCpp11.c
+++ b/src/idlcxx/src/backendCpp11.c
@@ -14,6 +14,8 @@
 #include <string.h>
 #include <stdlib.h>
 
+#include "strdup.h"
+
 /* Specify a list of all C++11 keywords */
 static const char* cpp11_keywords[] =
 {
@@ -54,6 +56,6 @@ get_cpp_name(const char* name)
     }
   }
   /* No match with a keyword is found, thus return the identifier itself */
-  cpp11Name = strdup(name);
+  cpp11Name = idl_strdup(name);
   return cpp11Name;
 }

--- a/src/idlcxx/src/strdup.h
+++ b/src/idlcxx/src/strdup.h
@@ -9,13 +9,15 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
-#ifndef IDL_VERSION_H
-#define IDL_VERSION_H
+#ifndef IDL_STRDUP_H
+#define IDL_STRDUP_H
 
-#define IDL_VERSION "@CycloneDDS_VERSION@"
-#define IDL_VERSION_MAJOR @CycloneDDS_VERSION_MAJOR@
-#define IDL_VERSION_MINOR @CycloneDDS_VERSION_MINOR@
-#define IDL_VERSION_PATCH @CycloneDDS_VERSION_PATCH@
-#define IDL_VERSION_TWEAK @CycloneDDS_VERSION_TWEAK@
+#include <string.h>
 
-#endif /* IDL_VERSION_H */
+#if _WIN32
+# define idl_strdup(s) _strdup(s)
+#else
+# define idl_strdup(s) strdup(s)
+#endif
+
+#endif /* IDL_STRDUP_H */

--- a/src/idlcxx/src/streamer_generator.c
+++ b/src/idlcxx/src/streamer_generator.c
@@ -332,6 +332,7 @@ void close_context(context_t* ctx)
   destruct_idl_ostream(ctx->read_stream);
 
   free(ctx->context);
+  free(ctx);
 }
 
 bool idl_is_base_type(idl_node_t* node)
@@ -899,7 +900,6 @@ idl_retcode_t process_module(context_t* ctx, idl_module_t* module)
     process_node(newctx, (idl_node_t*)module->definitions);
 
     close_context(newctx);
-    free(newctx);
 
     format_header_stream(1, ctx, namespace_closure_fmt, cpp11name);
     format_read_stream(1, ctx, namespace_closure_fmt, cpp11name);

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -762,8 +762,8 @@ void test_base(size_t n, bool ns)
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
 
   destruct_idl_ostream(impl);
-
   destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 void test_instance(bool ns)
@@ -802,8 +802,11 @@ void test_instance(bool ns)
   create_funcs_instance(impl, "mem", ns);
 
   CU_ASSERT_STRING_EQUAL(ns ? HNPI : HNAI, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
-
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+
+  destruct_idl_ostream(impl);
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 void test_sequence(size_t n, bool ns)
@@ -838,8 +841,11 @@ void test_sequence(size_t n, bool ns)
   create_funcs_sequence(impl, "mem", n, ns);
 
   CU_ASSERT_STRING_EQUAL(ns ? HNP : HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
-
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+
+  destruct_idl_ostream(impl);
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 void test_string(bool ns)
@@ -872,8 +878,11 @@ void test_string(bool ns)
   create_funcs_string(impl, "str", ns);
 
   CU_ASSERT_STRING_EQUAL(ns ? HNP : HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
-
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+
+  destruct_idl_ostream(impl);
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 void test_union(bool ns)
@@ -918,6 +927,10 @@ void test_union(bool ns)
 
   CU_ASSERT_STRING_EQUAL(ns ? HNP : HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+
+  destruct_idl_ostream(impl);
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 void test_enum(bool ns)
@@ -952,6 +965,10 @@ void test_enum(bool ns)
 
   CU_ASSERT_STRING_EQUAL(ns ? HNP : HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+
+  destruct_idl_ostream(impl);
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 void test_array_base(bool ns)
@@ -985,6 +1002,10 @@ void test_array_base(bool ns)
 
   CU_ASSERT_STRING_EQUAL(ns ? HNP : HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+
+  destruct_idl_ostream(impl);
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 void test_array_instance(bool ns)
@@ -1024,6 +1045,10 @@ void test_array_instance(bool ns)
 
   CU_ASSERT_STRING_EQUAL(ns ? HNPI : HNAI, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+
+  destruct_idl_ostream(impl);
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 void test_namespace_cross_call()
@@ -1039,6 +1064,9 @@ void test_namespace_cross_call()
 
   CU_ASSERT_STRING_EQUAL(CCFH, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
   CU_ASSERT_STRING_EQUAL(CCFI, get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 void test_struct_inheritance()
@@ -1058,6 +1086,9 @@ void test_struct_inheritance()
 
   CU_ASSERT_STRING_EQUAL(HNAI, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
   CU_ASSERT_STRING_EQUAL(IFI, get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 void test_bounded_sequence()
@@ -1075,6 +1106,9 @@ void test_bounded_sequence()
 
   CU_ASSERT_STRING_EQUAL(HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
   CU_ASSERT_STRING_EQUAL(BSI, get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 CU_Test(streamer_generator, base_types_namespace_absent)

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -13,11 +13,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
-#ifdef _WIN32
-#include <Windows.h>
-#else
-#define sprintf_s(ptr, len, str, ...) sprintf(ptr, str __VA_OPT__(,) __VA_ARGS__)
-#endif
 
 #include "idlcxx/streamer_generator.h"
 #include "idl/processor.h"
@@ -737,7 +732,7 @@ void test_base(size_t n, bool ns)
   char buffer[1024];
   if (ns)
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "module N {\n"\
       "struct s {\n"\
       "%s mem;\n"\
@@ -747,7 +742,7 @@ void test_base(size_t n, bool ns)
   }
   else
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "struct s {\n"\
       "%s mem;\n"\
       "};\n",
@@ -776,7 +771,7 @@ void test_instance(bool ns)
   char buffer[1024];
   if (ns)
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "module N {\n"\
       "struct I {\n"\
       "long l;\n"
@@ -788,7 +783,7 @@ void test_instance(bool ns)
   }
   else
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "struct I {\n"\
       "long l;\n"
       "};\n"
@@ -816,7 +811,7 @@ void test_sequence(size_t n, bool ns)
   char buffer[1024];
   if (ns)
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "module N {\n"\
       "struct s {\n"\
       "sequence<%s> mem;\n"\
@@ -826,7 +821,7 @@ void test_sequence(size_t n, bool ns)
   }
   else
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "struct s {\n"\
       "sequence<%s> mem;\n"\
       "};\n",
@@ -852,7 +847,7 @@ void test_string(bool ns)
   char buffer[1024];
   if (ns)
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "module N {\n"\
       "struct s {\n"\
       "string str;\n"\
@@ -861,7 +856,7 @@ void test_string(bool ns)
   }
   else
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "struct s {\n"\
       "string str;\n"\
       "};\n");
@@ -886,7 +881,7 @@ void test_union(bool ns)
   char buffer[1024];
   if (ns)
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "module N {\n"\
       "union s switch (long) {\n"\
       "case 0:\n"\
@@ -901,7 +896,7 @@ void test_union(bool ns)
   }
   else
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "union s switch (long) {\n"\
       "case 0:\n"\
       "case 1: octet o;\n"\
@@ -930,7 +925,7 @@ void test_enum(bool ns)
   char buffer[1024];
   if (ns)
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "module N {\n"\
       "enum E {e_0, e_1, e_2, e_3};\n"\
       "struct s {\n"\
@@ -940,7 +935,7 @@ void test_enum(bool ns)
   }
   else
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "enum E {e_0, e_1, e_2, e_3};\n"\
       "struct s {\n"\
       "E mem;\n"\
@@ -964,7 +959,7 @@ void test_array_base(bool ns)
   char buffer[1024];
   if (ns)
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "module N {\n"\
       "struct s {\n"\
       "float mem[3][2], mem2;\n"\
@@ -973,7 +968,7 @@ void test_array_base(bool ns)
   }
   else
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "struct s {\n"\
       "float mem[3][2], mem2;\n"\
       "};\n");
@@ -997,7 +992,7 @@ void test_array_instance(bool ns)
   char buffer[1024];
   if (ns)
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "module N {\n"\
       "struct I {\n"\
       "long l;\n"\
@@ -1009,7 +1004,7 @@ void test_array_instance(bool ns)
   }
   else
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "struct I {\n"\
       "long l;\n"\
       "};\n"\


### PR DESCRIPTION
Some minor additions so that macOS builds succeed (the `winflexbison3` Chocolatey package is currently broken, but everything should start working there automagically) and tests will run after the build completes.

Memory issues (at least those exposed by the tests) have been fixed and once this [PR](https://github.com/eclipse-cyclonedds/cyclonedds/pull/588) is merged, the builds that enable the AddressSanitizer will pass too.