### PR TITLE
Fix optional access in generated code

### DIFF
--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -115,7 +115,7 @@ static int get_instance_accessor(char* str, size_t size, const void* node, void*
 
     const idl_declarator_t* decl = (const idl_declarator_t*)node;
     const char* name = get_cpp11_name(decl);
-    return idl_snprintf(str, size, "%s%s.%s()", opt, loc.parent, name);
+    return idl_snprintf(str, size, "(%s%s.%s())", opt, loc.parent, name);
   }
 }
 


### PR DESCRIPTION
When accessing optional `foo.bar()` to call a method, `*foo.bar().baz()`
is not good enough, it should be `(*foo.bar()).baz()` or
`foo.bar()->baz()`.

Basically the pointer-deref operator doesn't bind where you'd expect.